### PR TITLE
Added configurations for Scoverage and Scalafix

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,6 @@
+rules = [
+  DisableSyntax
+]
+
+DisableSyntax.noVars = true
+DisableSyntax.noNulls = true

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,6 +1,28 @@
 rules = [
   DisableSyntax
+  NoValInForComprehension
+  RedundantSyntax
+  RemoveUnused
 ]
 
 DisableSyntax.noVars = true
+DisableSyntax.noThrows = false
 DisableSyntax.noNulls = true
+DisableSyntax.noReturns = false
+DisableSyntax.noWhileLoops = false
+DisableSyntax.noAsInstanceOf = false
+DisableSyntax.noIsInstanceOf = false
+DisableSyntax.noXml = false
+DisableSyntax.noDefaultArgs = false
+DisableSyntax.noFinalVal = false
+DisableSyntax.noFinalize = false
+DisableSyntax.noValPatterns = false
+DisableSyntax.noUniversalEquality = true
+DisableSyntax.noUniversalEqualityMessage = "use === instead of =="
+DisableSyntax.regex = [
+  {
+    id = "offensive"
+    pattern = "[Pp]imp"
+    message = "Please consider a less offensive word such as 'extension' or 'enrichment'"
+  }
+]

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "FormaLM Example",
     libraryDependencies += munit % Test,
-    semanticdbEnabled := true,
+    semanticdbEnabled := true, // necessary atm
     scalacOptions ++= List(
       "-Wunused"
     )

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,6 @@ lazy val root = (project in file("."))
     libraryDependencies += munit % Test,
     semanticdbEnabled := true, // necessary atm
     scalacOptions ++= List(
-      "-Wunused"
+      "-Wunused" // necessary atm
     )
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("org.scoverage"             % "sbt-scoverage" % "2.0.6") // necessary atm
+addSbtPlugin("ch.epfl.scala"            %% "sbt-scalafix"  % "0.10.4") // necessary atm


### PR DESCRIPTION
The idea with this PR is to have this project in a state where both tools that are usable in the formalm project have all the configuration already added. That way, we can assume that in the formalm project and iterate towards improvements that can have less assumptions on the projects that can be analyzed.
cc: @javipacheco @Montagon 